### PR TITLE
Make basic colour drawing work

### DIFF
--- a/.todo
+++ b/.todo
@@ -1,0 +1,1 @@
+[ ] Migrate panel, geometry, and draw to use windows/screens.

--- a/src/coordinate.c
+++ b/src/coordinate.c
@@ -1,5 +1,4 @@
 #include <math.h>
-#include <stdbool.h>
 #include <stdlib.h>
 
 #include "include/coordinate.h"

--- a/src/draw.c
+++ b/src/draw.c
@@ -196,22 +196,25 @@ void draw_reticule(struct Geometry *g)
 
     float slope = geometry_slope(g);
     int rmid = geometry_rmid(g), cmid = geometry_cmid(g);
-    int w_half = (geometry_hex_w(g)+1)/2, h_half = (geometry_hex_h(g)+1)/2;
+    int w_half = (geometry_hex_w(g)+1)/2, h_half = (geometry_hex_h(g))/2;
 
-    mvvline(rmid-h_half, cmid-w_half, ch, 2*h_half);
-    mvvline(rmid-h_half, cmid+w_half, ch, 2*h_half);
+    attron(COLOR_PAIR(COLOR_RED));
 
-    mvvline(rmid-h_half, cmid-w_half+1, ch, 2*h_half);
-    mvvline(rmid-h_half, cmid+w_half-1, ch, 2*h_half);
+    mvvline(rmid-h_half + 1, cmid-w_half, ch, 2*h_half + 1);
+    mvvline(rmid-h_half + 1, cmid+w_half, ch, 2*h_half + 1);
+
+    mvvline(rmid-h_half + 1, cmid-w_half+1, ch, 2*h_half + 1);
+    mvvline(rmid-h_half + 1, cmid+w_half-1, ch, 2*h_half + 1);
 
     for (int col = -w_half; col <= w_half; col++) {
         dh = (col < 0)
             ? floor((w_half+col)*slope)
             : floor((w_half-col)*slope);
         mvaddch(rmid - (h_half + dh), cmid + col, ch);
-        mvaddch(rmid + (h_half + dh), cmid + col, ch);
+        mvaddch(rmid + (h_half + dh)+1, cmid + col, ch);
     }
 
+    attroff(COLOR_PAIR(COLOR_RED));
     return;
 }
 
@@ -223,16 +226,21 @@ int draw_hex(struct Geometry *g, struct Hex *hex, int r0, int c0)
     int dh = 0;
     char ch = 0;
 
+    enum TERRAIN t = hex_terrain(hex);
+    int s = hex_seed(hex);
+
+    attron(COLOR_PAIR(terrain_colour(t)));
     for (int c = -w_half; c <= w_half; c++) {
         dh = (c < 0)
                 ? floor((w_half+c)*geometry_slope(g))
                 : floor((w_half-c)*geometry_slope(g));
 
-        for (int r = -(h_half + dh); r <= (h_half + dh); r++) {
-            ch = terrain_getch(hex_terrain(hex), c, r, hex_seed(hex));
+        for (int r = -(h_half + dh)+1; r <= (h_half + dh); r++) {
+            ch = terrain_getch(t, c, r, s);
             mvaddch(r0 + r, c0 + c, ch);
         }
     }
+    attroff(COLOR_PAIR(terrain_colour(t)));
     return 0;
 }
 

--- a/src/draw.c
+++ b/src/draw.c
@@ -3,6 +3,7 @@
 #include <math.h>
 
 #include "include/draw.h"
+#include "include/terrain.h"
 
 
 /*
@@ -186,30 +187,6 @@ int clear_panel(struct Panel *p)
  *      DRAW 03 - Hexes and terrain
  */
 
-char get_terrainchr(enum TERRAIN t)
-{
-    switch (t) {
-        case WATER:
-            return '~';
-        case MOUNTAINS:
-            return '^';
-        case PLAINS:
-            return ';';
-        case HILLS:
-            return 'n';
-        case FOREST:
-            return 'T';
-        case DESERT:
-            return '*';
-        case JUNGLE:
-            return '#';
-        case SWAMP:
-            return 'j';
-        default:
-            break;
-    }
-    return '?';
-}
 
 
 void draw_reticule(struct Geometry *g)
@@ -219,7 +196,7 @@ void draw_reticule(struct Geometry *g)
 
     float slope = geometry_slope(g);
     int rmid = geometry_rmid(g), cmid = geometry_cmid(g);
-    int w_half = geometry_hex_w(g)/2, h_half = geometry_hex_h(g)/2;
+    int w_half = (geometry_hex_w(g)+1)/2, h_half = (geometry_hex_h(g)+1)/2;
 
     mvvline(rmid-h_half, cmid-w_half, ch, 2*h_half);
     mvvline(rmid-h_half, cmid+w_half, ch, 2*h_half);
@@ -229,8 +206,8 @@ void draw_reticule(struct Geometry *g)
 
     for (int col = -w_half; col <= w_half; col++) {
         dh = (col < 0)
-            ? round((w_half+col)*slope)
-            : round((w_half-col)*slope);
+            ? floor((w_half+col)*slope)
+            : floor((w_half-col)*slope);
         mvaddch(rmid - (h_half + dh), cmid + col, ch);
         mvaddch(rmid + (h_half + dh), cmid + col, ch);
     }
@@ -241,18 +218,18 @@ void draw_reticule(struct Geometry *g)
 
 int draw_hex(struct Geometry *g, struct Hex *hex, int r0, int c0)
 {
-    int w_half = geometry_hex_w(g) / 2,
-        h_half = geometry_hex_h(g) / 2;
+    int w_half = (geometry_hex_w(g)+1) / 2,
+        h_half = (geometry_hex_h(g)+1) / 2;
     int dh = 0;
-
-    char ch = get_terrainchr(hex_terrain(hex));
+    char ch = 0;
 
     for (int c = -w_half; c <= w_half; c++) {
         dh = (c < 0)
-                ? round((w_half+c)*geometry_slope(g))
-                : round((w_half-c)*geometry_slope(g));
+                ? floor((w_half+c)*geometry_slope(g))
+                : floor((w_half-c)*geometry_slope(g));
 
         for (int r = -(h_half + dh); r <= (h_half + dh); r++) {
+            ch = terrain_getch(hex_terrain(hex), c, r, hex_seed(hex));
             mvaddch(r0 + r, c0 + c, ch);
         }
     }

--- a/src/grid.c
+++ b/src/grid.c
@@ -56,6 +56,11 @@ int seed_gen(const struct Coordinate *c)
     return (x * 73856093) ^ (y * 19349963) ^ (z * 83492791) ^ (seed_count++ * 5821);
 }
 
+int seed_prng(const int x, const int y, const int seed, const int max)
+{
+    return ((((x * 73856093) ^ (y * 19349963) ^ (seed * 83492791)) % max) + max) % max;
+}
+
 struct Hex {
     int seed;
     struct Coordinate *coordinate;

--- a/src/grid.c
+++ b/src/grid.c
@@ -47,7 +47,17 @@ const char *terrain_string(enum TERRAIN t)
     return terrain_none;
 }
 
+static int seed_count = 0;
+int seed_gen(const struct Coordinate *c)
+{
+    int x = coordinate_p(c),
+        y = coordinate_q(c),
+        z = coordinate_r(c);
+    return (x * 73856093) ^ (y * 19349963) ^ (z * 83492791) ^ (seed_count++ * 5821);
+}
+
 struct Hex {
+    int seed;
     struct Coordinate *coordinate;
     enum TERRAIN terrain;
     struct Hex **children;
@@ -100,6 +110,7 @@ struct Hex *hex_create(const struct Coordinate *c)
 
     /* other data */
     /* TODO? separate struct Tile containing all terrain-like data, for nullability */
+    h->seed = seed_gen(c);
     h->terrain = TERRAIN_UNKNOWN;
 
     return h;
@@ -169,6 +180,12 @@ struct Coordinate *hex_coordinate(struct Hex *hex)
 unsigned int hex_m(struct Hex *hex)
 {
     return coordinate_magnitude(hex->coordinate);
+}
+
+
+int hex_seed(struct Hex *hex)
+{
+    return hex->seed;
 }
 
 

--- a/src/grid.c
+++ b/src/grid.c
@@ -10,44 +10,8 @@
  * Terrain lookups
  *
  */
-
-const char *terrain_none = "None";
-const char *terrain_water = "Water";
-const char *terrain_mountains = "Mountains";
-const char *terrain_plains = "Plains";
-const char *terrain_hills = "Hills";
-const char *terrain_forest = "Forset";
-const char *terrain_desert = "Desert";
-const char *terrain_jungle = "Jungle";
-const char *terrain_swamp = "Swamp";
-
-
-const char *terrain_string(enum TERRAIN t)
-{
-    switch (t) {
-        case WATER:
-            return terrain_water;
-        case MOUNTAINS:
-            return terrain_mountains;
-        case PLAINS:
-            return terrain_plains;
-        case HILLS:
-            return terrain_hills;
-        case FOREST:
-            return terrain_forest;
-        case DESERT:
-            return terrain_desert;
-        case JUNGLE:
-            return terrain_jungle;
-        case SWAMP:
-            return terrain_swamp;
-        default:
-            break;
-    }
-    return terrain_none;
-}
-
 static int seed_count = 0;
+
 int seed_gen(const struct Coordinate *c)
 {
     int x = coordinate_p(c),

--- a/src/include/coordinate.h
+++ b/src/include/coordinate.h
@@ -1,6 +1,8 @@
 #ifndef COORDINATE_H
 #define COORDINATE_H
 
+#include <stdbool.h>
+
 #include "enum.h"
 
 

--- a/src/include/enum.h
+++ b/src/include/enum.h
@@ -1,6 +1,14 @@
 #ifndef ENUM_H
 #define ENUM_H
 
+
+enum UI_COLOUR {
+    COLOUR_NONE,
+    COLOUR_SOME,
+    COLOUR_MANY
+};
+
+
 #define UI_NUM_PANELS 3
 enum UI_PANEL {
    PANEL_SPLASH,

--- a/src/include/grid.h
+++ b/src/include/grid.h
@@ -28,6 +28,7 @@ void hex_set_terrain(struct Hex *h, enum TERRAIN t);
 enum TERRAIN hex_terrain(struct Hex *h);
 
 /* Geometry-like */
+int hex_seed(struct Hex *hex);
 int hex_p(struct Hex *hex);
 int hex_q(struct Hex *hex);
 int hex_r(struct Hex *hex);

--- a/src/include/grid.h
+++ b/src/include/grid.h
@@ -29,6 +29,7 @@ enum TERRAIN hex_terrain(struct Hex *h);
 
 /* Geometry-like */
 int hex_seed(struct Hex *hex);
+int seed_prng(const int x, const int y, const int seed, const int max);
 int hex_p(struct Hex *hex);
 int hex_q(struct Hex *hex);
 int hex_r(struct Hex *hex);

--- a/src/include/terrain.h
+++ b/src/include/terrain.h
@@ -5,5 +5,6 @@
 
 const char *terrain_name(enum TERRAIN t);
 char terrain_getch(enum TERRAIN t, int x, int y, int seed);
+int terrain_colour(enum TERRAIN t);
 
 #endif

--- a/src/include/terrain.h
+++ b/src/include/terrain.h
@@ -1,0 +1,9 @@
+#ifndef TERRAIN_H
+#define TERRAIN_H
+
+#include "enum.h"
+
+const char *terrain_name(enum TERRAIN t);
+char terrain_getch(enum TERRAIN t, int x, int y, int seed);
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -10,6 +10,8 @@
 #include "include/draw.h"
 #include "include/interface.h"
 #include "include/key.h"
+#include "include/terrain.h"
+
 
 struct StateManager {
     bool quit;
@@ -61,7 +63,7 @@ void update_vars(void)
     char *terrain = malloc(32);
     snprintf(terrain, 32,
             "    Terrain: %s",
-            terrain_string(hex_terrain(current_hex))
+            terrain_name(hex_terrain(current_hex))
             );
     panel_remove_line(hex_detail, 2);
     panel_add_line(hex_detail, 2, terrain);

--- a/src/main.c
+++ b/src/main.c
@@ -66,10 +66,21 @@ void update_vars(void)
     panel_remove_line(hex_detail, 2);
     panel_add_line(hex_detail, 2, terrain);
 
+    int seed = hex_seed(current_hex);
+    char *seedstr = malloc(32);
+    snprintf(seedstr, 32,
+            "  Seed: %d",
+            seed
+            );
+    panel_remove_line(hex_detail, 3);
+    panel_add_line(hex_detail, 3, seedstr);
+
     free(coordinate);
     free(terrain);
+    free(seedstr);
     coordinate = NULL;
     terrain = NULL;
+    seedstr = NULL;
     return;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -16,6 +16,7 @@
 struct StateManager {
     bool quit;
     enum INPUTMODE input_mode;
+    enum UI_COLOUR colours;
 };
 
 
@@ -25,6 +26,7 @@ struct StateManager *state_create(void)
 
     s->quit = false;
     s->input_mode = INPUT_NONE;
+    s->colours = COLOUR_NONE;
 
     return s;
 }
@@ -97,6 +99,24 @@ int initialise(void)
 
     sm = state_create();
     sm->input_mode = INPUT_CAPTURE;
+
+    /* set up colours */
+    sm->colours = (has_colors())
+        ? ((can_change_color()) ? COLOUR_MANY : COLOUR_SOME)
+        : COLOUR_NONE;
+
+
+    if (sm->colours == COLOUR_SOME || sm->colours == COLOUR_MANY) {
+        start_color();
+        init_pair(1, COLOR_RED, COLOR_BLACK);
+        init_pair(2, COLOR_GREEN, COLOR_BLACK);
+        init_pair(3, COLOR_YELLOW, COLOR_BLACK);
+        init_pair(4, COLOR_BLUE, COLOR_BLACK);
+        init_pair(5, COLOR_MAGENTA, COLOR_BLACK);
+        init_pair(6, COLOR_CYAN, COLOR_BLACK);
+        init_pair(7, COLOR_WHITE, COLOR_BLACK);
+    }
+
 
     /* TODO remove magic numbers and have a geometry_initialise that takes a screen */
     int r0, c0;

--- a/src/panel.c
+++ b/src/panel.c
@@ -168,7 +168,7 @@ struct Panel *panel_splash(void)
 
 struct Panel *panel_terrain_selector(void)//int rmid, int cmid)
 {
-    struct Panel *terrain_selector = panel_create(9, 2, 5);
+    struct Panel *terrain_selector = panel_create(10, 2, 5);
     panel_add_line(terrain_selector, 0, "Select Terrain:");
     panel_add_line(terrain_selector, 1, "1. Ocean     2. Mountain 3. Plains");
     panel_add_line(terrain_selector, 2, "4. Hills     5. Forest   6. Desert");
@@ -180,10 +180,11 @@ struct Panel *panel_terrain_selector(void)//int rmid, int cmid)
 
 struct Panel *panel_hex_detail(void)
 {
-    struct Panel *hex_detail = panel_create(2, 2, 3);
+    struct Panel *hex_detail = panel_create(2, 2, 4);
     panel_add_line(hex_detail, 0, "Currently at: ");
     panel_add_line(hex_detail, 1, "    (p, q, r)");
     panel_add_line(hex_detail, 2, "    TERRAIN: NONE");
+    panel_add_line(hex_detail, 3, "  SEED: 0");
 
     return hex_detail;
 }

--- a/src/terrain.c
+++ b/src/terrain.c
@@ -1,3 +1,4 @@
+#include <ncurses.h>
 #include <stddef.h>
 
 #include "include/terrain.h"
@@ -14,13 +15,13 @@ const char *terrain_jungle = "Jungle";
 const char *terrain_swamp = "Swamp";
 
 #define NUM_TERRAIN_CHOPTS 12
-const char *terrain_chopts_unknown      = "  ??????????";
+const char *terrain_chopts_unknown      = "         ??*";
 const char *terrain_chopts_water        = "    ~~~~~~~~";
-const char *terrain_chopts_mountains    = "   ..^^^^AAV";
+const char *terrain_chopts_mountains    = "    ..^^^AAA";
 const char *terrain_chopts_plains       = "      ,,,;;t";
 const char *terrain_chopts_hills        = "      ,;nnnn";
 const char *terrain_chopts_forest       = "    ttttTT44";
-const char *terrain_chopts_desert       = "     ....nn*";
+const char *terrain_chopts_desert       = "     .....nn";
 const char *terrain_chopts_jungle       = "    ttt&%$#@";
 const char *terrain_chopts_swamp        = "    iijj%~%~";
 
@@ -76,11 +77,35 @@ const char *terrain_chopts(enum TERRAIN t)
 }
 
 
-
 char terrain_getch(enum TERRAIN t, int x, int y, int seed)
 {
     const char *chopts = terrain_chopts(t);
     int offset = (int)t;
 
     return chopts[seed_prng(x, y, seed + offset, NUM_TERRAIN_CHOPTS)];
+}
+
+
+int terrain_colour(enum TERRAIN t)
+{
+    switch (t) {
+        case WATER:
+            return COLOR_BLUE;
+        case MOUNTAINS:
+            return COLOR_WHITE;
+        case PLAINS:
+            return COLOR_GREEN;
+        case HILLS:
+            return COLOR_YELLOW;
+        case FOREST:
+            return COLOR_GREEN;
+        case DESERT:
+            return COLOR_YELLOW;
+        case JUNGLE:
+            return COLOR_GREEN;
+        case SWAMP:
+            return COLOR_CYAN;
+        default:
+            return COLOR_WHITE;
+    }
 }

--- a/src/terrain.c
+++ b/src/terrain.c
@@ -15,14 +15,14 @@ const char *terrain_jungle = "Jungle";
 const char *terrain_swamp = "Swamp";
 
 #define NUM_TERRAIN_CHOPTS 12
-const char *terrain_chopts_unknown      = "         ??*";
+const char *terrain_chopts_unknown      = "          ?*";
 const char *terrain_chopts_water        = "    ~~~~~~~~";
 const char *terrain_chopts_mountains    = "    ..^^^AAA";
 const char *terrain_chopts_plains       = "      ,,,;;t";
 const char *terrain_chopts_hills        = "      ,;nnnn";
 const char *terrain_chopts_forest       = "    ttttTT44";
-const char *terrain_chopts_desert       = "     .....nn";
-const char *terrain_chopts_jungle       = "    ttt&%$#@";
+const char *terrain_chopts_desert       = "    ......nn";
+const char *terrain_chopts_jungle       = "    tT4&%$#@";
 const char *terrain_chopts_swamp        = "    iijj%~%~";
 
 

--- a/src/terrain.c
+++ b/src/terrain.c
@@ -1,0 +1,86 @@
+#include <stddef.h>
+
+#include "include/terrain.h"
+#include "include/grid.h"
+
+const char *terrain_unknown = "Unknown";
+const char *terrain_water = "Water";
+const char *terrain_mountains = "Mountains";
+const char *terrain_plains = "Plains";
+const char *terrain_hills = "Hills";
+const char *terrain_forest = "Forest";
+const char *terrain_desert = "Desert";
+const char *terrain_jungle = "Jungle";
+const char *terrain_swamp = "Swamp";
+
+#define NUM_TERRAIN_CHOPTS 12
+const char *terrain_chopts_unknown      = "  ??????????";
+const char *terrain_chopts_water        = "    ~~~~~~~~";
+const char *terrain_chopts_mountains    = "   ..^^^^AAV";
+const char *terrain_chopts_plains       = "      ,,,;;t";
+const char *terrain_chopts_hills        = "      ,;nnnn";
+const char *terrain_chopts_forest       = "    ttttTT44";
+const char *terrain_chopts_desert       = "     ....nn*";
+const char *terrain_chopts_jungle       = "    ttt&%$#@";
+const char *terrain_chopts_swamp        = "    iijj%~%~";
+
+
+const char *terrain_name(enum TERRAIN t)
+{
+    switch (t) {
+        case WATER:
+            return terrain_water;
+        case MOUNTAINS:
+            return terrain_mountains;
+        case PLAINS:
+            return terrain_plains;
+        case HILLS:
+            return terrain_hills;
+        case FOREST:
+            return terrain_forest;
+        case DESERT:
+            return terrain_desert;
+        case JUNGLE:
+            return terrain_jungle;
+        case SWAMP:
+            return terrain_swamp;
+        default:
+            break;
+    }
+    return terrain_unknown;
+}
+
+
+const char *terrain_chopts(enum TERRAIN t)
+{
+    switch (t) {
+        case WATER:
+            return terrain_chopts_water;
+        case MOUNTAINS:
+            return terrain_chopts_mountains;
+        case PLAINS:
+            return terrain_chopts_plains;
+        case HILLS:
+            return terrain_chopts_hills;
+        case FOREST:
+            return terrain_chopts_forest;
+        case DESERT:
+            return terrain_chopts_desert;
+        case JUNGLE:
+            return terrain_chopts_jungle;
+        case SWAMP:
+            return terrain_chopts_swamp;
+        default:
+            return terrain_chopts_unknown;
+    }
+}
+
+
+
+char terrain_getch(enum TERRAIN t, int x, int y, int seed)
+{
+    const char *chopts = terrain_chopts(t);
+    int offset = (int)t;
+
+    return chopts[seed_prng(x, y, seed + offset, NUM_TERRAIN_CHOPTS)];
+}


### PR DESCRIPTION
Each hex is generated with a seed. This seed is used to prng select from a string of
character options when drawing a hex. A single block colour is used for each terrain
type. Colour testing happends (for terminal capability) but currently does nothing,
colours are always used.
