### PR TITLE
Improve mode switching

### DIFF
--- a/src/action.c
+++ b/src/action.c
@@ -7,6 +7,26 @@
 #include "include/tile.h"
 
 
+void action_mode(struct State *state, enum MODE m)
+{
+    if (state_await(state)) {
+        state_pop_mode(state);
+        return;
+    }
+
+    /* don't set an await mode for the currently select mode! */
+    if (state_mode(state) == mode_drop_await(m)) {
+        return;
+    }
+
+    if ((m == state_mode(state)) || (m == MODE_NONE)) {
+        state_push_mode(state, MODE_NAVIGATE);
+    } else {
+        state_push_mode(state, m);
+    }
+}
+
+
 void action_move(struct State *s, enum DIRECTION d, int steps)
 {
     for (int i = steps; i > 0; i--) {
@@ -54,7 +74,7 @@ void action_capture(struct State *s, key k)
         ui_toggle(state_ui(s), PANEL_SPLASH);
     }
 
-    state_set_mode(s, MODE_NAVIGATE);
+    state_push_mode(s, MODE_NAVIGATE);
 }
 
 
@@ -66,26 +86,7 @@ void action_navigate(struct State *s, key k)
     }
 
     if (key_is_mode(k)) {
-        switch (k) {
-            case KEY_MODE_COMMAND:
-                state_set_mode(s, MODE_COMMAND);
-                break;
-            case KEY_MODE_AWAIT_TERRAIN:
-                state_set_await(s, true);
-                /* fall through */
-            case KEY_MODE_TERRAIN:
-                state_set_mode(s, MODE_TERRAIN);
-                break;
-            case KEY_MODE_AWAIT_ROAD:
-                state_set_await(s, true);
-                /* fall through */
-            case KEY_MODE_ROAD:
-                state_set_mode(s, MODE_ROAD);
-                break;
-            default:
-                break;
-        }
-        return;
+        action_mode(s, key_mode(k));
     }
 
     switch (k) {
@@ -103,11 +104,10 @@ void action_navigate(struct State *s, key k)
 void action_terrain(struct State *s, key k)
 {
     if (state_await(s)) {
-        state_set_await(s, false);
         if (key_is_terrain(k)) {
             action_paint_terrain(s, key_terrain(k));
         }
-        state_set_mode(s, MODE_NAVIGATE);
+        action_mode(s, key_mode(k));
         return;
     }
 
@@ -128,13 +128,8 @@ void action_terrain(struct State *s, key k)
         }
     }
 
-    switch (k) {
-        case KEY_MODE_TERRAIN:
-        case KEY_ESCAPE:
-            state_set_mode(s, MODE_NAVIGATE);
-            return;
-        default:
-            break;
+    if (key_is_mode(k)) {
+        action_mode(s, key_mode(k));
     }
     return;
 }
@@ -146,7 +141,7 @@ void action_command(struct State *s, key k)
     switch (k) {
         case KEY_ESCAPE:
             commandline_reset(state_commandline(s));
-            state_set_mode(s, MODE_NAVIGATE);
+            state_pop_mode(s);
             return;
 
         /* send command to be parsed */
@@ -160,7 +155,7 @@ void action_command(struct State *s, key k)
                     break;
             }
             commandline_reset(state_commandline(s));
-            state_set_mode(s, MODE_NAVIGATE);
+            state_pop_mode(s);
             command_destroy(c);
             return;
 
@@ -170,7 +165,7 @@ void action_command(struct State *s, key k)
         case 127:
             if (commandline_len(state_commandline(s)) <= 0) {
                 commandline_reset(state_commandline(s));
-                state_set_mode(s, MODE_NAVIGATE);
+                state_pop_mode(s);
             }
             commandline_popch(state_commandline(s));
             return;
@@ -188,11 +183,10 @@ void action_command(struct State *s, key k)
 void action_road(struct State *s, key k)
 {
     if (state_await(s)) {
-        state_set_await(s, false);
         if (key_is_direction(k)) {
             action_paint_road(s, key_direction(k));
         }
-        state_set_mode(s, MODE_NAVIGATE);
+        action_mode(s, key_mode(k));
         return;
     }
 
@@ -204,13 +198,8 @@ void action_road(struct State *s, key k)
         }
     }
 
-    switch (k) {
-        case KEY_MODE_ROAD:
-        case KEY_ESCAPE:
-            state_set_mode(s, MODE_NAVIGATE);
-            return;
-        default:
-            break;
+    if (key_is_mode(k)) {
+        action_mode(s, key_mode(k));
     }
     return;
 }

--- a/src/draw.c
+++ b/src/draw.c
@@ -304,8 +304,17 @@ void wdraw_statusline(WINDOW *win, struct State *s)
         w  = geometry_cols(state_geometry(s))-1;
 
     mvwhline(win, r0, c0, ' ', w);
+    wmove(win, r0, c0+1);
+
+    if (state_await(s)) {
+        attron(COLOR_PAIR(mode_colour(state_lastmode(s))));
+        waddstr(win, mode_name(state_lastmode(s)));
+        attroff(COLOR_PAIR(mode_colour(state_lastmode(s))));
+        addch(' ');
+    }
+
     attron(COLOR_PAIR(mode_colour(state_mode(s))));
-    mvwaddstr(win, r0, c0+1, mode_name(state_mode(s)));
+    waddstr(win, mode_name(state_mode(s)));
     attroff(COLOR_PAIR(mode_colour(state_mode(s))));
 
     switch (state_mode(s)) {
@@ -315,6 +324,7 @@ void wdraw_statusline(WINDOW *win, struct State *s)
             addstr(commandline_str(state_commandline(s)));
             break;
         case MODE_TERRAIN:
+        case MODE_AWAIT_TERRAIN:
             addch(' ');
             attron(COLOR_PAIR(COLOR_YELLOW));
             for (const char *c = terrain_statusline(); *c != '\0'; c++) {

--- a/src/enum.c
+++ b/src/enum.c
@@ -157,11 +157,13 @@ const char *terrain_statusline(void)
 
 /*  MODE : Constants */
 
-const char *modestr_navigate = "NAVIGATE";
-const char *modestr_terrain  = "TERRAIN";
-const char *modestr_command  = "COMMAND";
-const char *modestr_road     = "ROADS";
-const char *modestr_unknown  = "???";
+const char *modestr_navigate        = "[NAVIGATE]";
+const char *modestr_terrain         = "[TERRAIN]";
+const char *modestr_command         = "[COMMAND]";
+const char *modestr_road            = "[ROADS]";
+const char *modestr_await_terrain   = "(terrain)";
+const char *modestr_await_road      = "(roads)";
+const char *modestr_unknown         = "???";
 
 
 /*  MODE : Functions */
@@ -174,27 +176,57 @@ const char *mode_name(enum MODE m)
             return modestr_navigate;
         case MODE_TERRAIN:
             return modestr_terrain;
+        case MODE_AWAIT_TERRAIN:
+            return modestr_await_terrain;
+        case MODE_AWAIT_ROAD:
+            return modestr_await_road;
         case MODE_ROAD:
             return modestr_road;
         case MODE_COMMAND:
             return modestr_command;
         default:
-            return modestr_unknown;
+            break;
     }
+    return modestr_unknown;
 }
 
 int mode_colour(enum MODE m)
 {
     switch (m) {
-        case MODE_NAVIGATE:
-            return COLOR_WHITE;
         case MODE_TERRAIN:
+        case MODE_AWAIT_TERRAIN:
             return COLOR_GREEN;
-        case MODE_COMMAND:
-            return COLOR_RED;
         case MODE_ROAD:
+        case MODE_AWAIT_ROAD:
             return COLOR_YELLOW;
-        default:
-            return COLOR_WHITE;
+        case MODE_COMMAND: return COLOR_RED;
+        case MODE_NAVIGATE: return COLOR_WHITE;
+        default: break;
     }
+    return COLOR_WHITE;
+}
+
+
+bool mode_is_await(enum MODE m)
+{
+    switch (m) {
+        case MODE_AWAIT_ROAD:
+        case MODE_AWAIT_TERRAIN:
+            return true;
+        default: break;
+    }
+    return false;;
+}
+
+
+enum MODE mode_drop_await(enum MODE m)
+{
+    switch (m) {
+        case MODE_AWAIT_ROAD:
+            return MODE_ROAD;
+        case MODE_AWAIT_TERRAIN:
+            return MODE_TERRAIN;
+        default: break;
+    }
+    return m;;
 }

--- a/src/include/enum.h
+++ b/src/include/enum.h
@@ -24,11 +24,15 @@ enum MODE {
     MODE_CAPTURE,
     MODE_NAVIGATE,
     MODE_TERRAIN,
+    MODE_AWAIT_TERRAIN,
     MODE_ROAD,
+    MODE_AWAIT_ROAD,
     MODE_COMMAND
 };
 const char *mode_name(enum MODE m);
 int mode_colour(enum MODE m);
+bool mode_is_await(enum MODE m);
+enum MODE mode_drop_await(enum MODE m);
 
 
 #define NUM_TERRAIN 9

--- a/src/include/key.h
+++ b/src/include/key.h
@@ -46,6 +46,7 @@ bool key_is_direction(key k);
 bool key_is_special(key k);
 bool key_is_terrain(key k);
 bool key_is_mode(key k);
+bool key_is_await(key k);
 
 enum DIRECTION key_direction(key k);
 enum TERRAIN key_terrain(key k);

--- a/src/include/state.h
+++ b/src/include/state.h
@@ -16,7 +16,9 @@ struct Atlas *state_atlas(const struct State *s);
 struct UserInterface *state_ui(const struct State *s);
 struct Commandline *state_commandline(const struct State *s);
 enum MODE state_mode(const struct State *s);
-void state_set_mode(struct State *s, enum MODE mode);
+enum MODE state_lastmode(const struct State *state);
+void state_push_mode(struct State *s, enum MODE mode);
+void state_pop_mode(struct State *state);
 char *state_charbuf(struct State *s);
 void state_reset_charbuf(struct State *s);
 void state_reset_nextchar(struct State *s);
@@ -25,13 +27,9 @@ enum UI_COLOUR state_colour(struct State *s);
 void state_set_colour(struct State *s, enum UI_COLOUR colour);
 bool state_await(struct State *s);
 WINDOW *state_window(struct State *s);
-void state_set_await(struct State *s, bool await);
 bool state_quit(struct State *s);
 void state_set_quit(struct State *s, bool quit);
 key state_currkey(struct State *s);
 void state_set_currkey(struct State *s, key k);
-void state_set_mode(struct State *s, enum MODE mode);
-int state_mode_colour(const struct State *s);
-const char *state_mode_name(const struct State *s);
 
 #endif

--- a/src/key.c
+++ b/src/key.c
@@ -113,6 +113,7 @@ bool key_is_terrain(key k)
 bool key_is_mode(key k)
 {
     switch (k) {
+        case KEY_ESCAPE:
         case KEY_MODE_COMMAND:
         case KEY_MODE_AWAIT_TERRAIN:
         case KEY_MODE_TERRAIN:
@@ -121,6 +122,32 @@ bool key_is_mode(key k)
             return true;
         default:
             break;
+    }
+    return false;
+}
+
+
+enum MODE key_mode(key k)
+{
+    switch (k) {
+        case KEY_MODE_COMMAND: return MODE_COMMAND;
+        case KEY_MODE_AWAIT_TERRAIN: return MODE_AWAIT_TERRAIN;
+        case KEY_MODE_TERRAIN: return MODE_TERRAIN;
+        case KEY_MODE_AWAIT_ROAD: return MODE_AWAIT_ROAD;
+        case KEY_MODE_ROAD: return MODE_ROAD;
+        default: break;
+    }
+    return MODE_NONE;
+}
+
+
+bool key_is_await(key k)
+{
+    switch (k) {
+        case KEY_MODE_AWAIT_TERRAIN:
+        case KEY_MODE_AWAIT_ROAD:
+            return true;
+        default: break;
     }
     return false;
 }

--- a/src/state.c
+++ b/src/state.c
@@ -17,11 +17,11 @@
 
 struct State {
     bool quit;
-    bool await;
     bool reticule;
 
     key currkey;
     enum MODE mode;
+    enum MODE lastmode;
 
     WINDOW *win;
     enum UI_COLOUR colour;
@@ -38,7 +38,6 @@ struct State *state_create(void)
     struct State *s = malloc(sizeof(struct State));
 
     s->quit = false;
-    s->await = false;
     s->reticule = false;
     s->currkey = 0;
     s->mode = MODE_NONE;
@@ -57,7 +56,7 @@ struct State *state_create(void)
 void state_initialise(struct State *s, WINDOW *win)
 {
     s->win = win;
-    state_set_mode(s, MODE_CAPTURE);
+    state_push_mode(s, MODE_CAPTURE);
 
     /* set up colour */
     enum UI_COLOUR colour = (has_colors() == TRUE)
@@ -99,12 +98,14 @@ void state_update(struct State *s)
             action_navigate(s, k);
             break;
         case MODE_TERRAIN:
+        case MODE_AWAIT_TERRAIN:
             action_terrain(s, k);
             break;
         case MODE_COMMAND:
             action_command(s, k);
             break;
         case MODE_ROAD:
+        case MODE_AWAIT_ROAD:
             action_road(s, k);
         case MODE_NONE:
         default:
@@ -158,9 +159,22 @@ enum MODE state_mode(const struct State *s)
 }
 
 
-void state_set_mode(struct State *s, enum MODE mode)
+enum MODE state_lastmode(const struct State *state)
 {
+    return state->lastmode;
+}
+
+
+void state_push_mode(struct State *s, enum MODE mode)
+{
+    s->lastmode = s->mode;
     s->mode = mode;
+}
+
+
+void state_pop_mode(struct State *state)
+{
+    state->mode = state->lastmode;
 }
 
 
@@ -202,19 +216,13 @@ void state_set_colour(struct State *s, enum UI_COLOUR colour)
 
 bool state_await(struct State *s)
 {
-    return s->await;
+    return mode_is_await(state_mode(s));
 }
 
 
 WINDOW *state_window(struct State *s)
 {
     return s->win;
-}
-
-
-void state_set_await(struct State *s, bool await)
-{
-    s->await = await;
 }
 
 


### PR DESCRIPTION
Mode switching now handled by generic action_mode function; mode switching possible from any painting mode to any other, and previous mode returned to when exiting an await state