### PR TITLE
Simplify the internal command line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,4 @@ format:
 
 tags:
 	ctags src/*.c src/include/*.h
+.PHONY: tags

--- a/src/action.c
+++ b/src/action.c
@@ -247,49 +247,45 @@ void action_terrain(struct State *state, key k)
 
 void action_command(struct State *state, key k)
 {
-    struct Commandline *commandline = state_commandline(state);
-    struct Command *c = NULL;
-
     switch (k) {
         case KEY_ESCAPE:
-            commandline_reset(commandline);
+            commandline_reset();
             state_pop_mode(state);
             return;
 
         case KEY_ENTER:
         case '\n':
-            c = commandline_parse(commandline);
-            switch (command_type(c)) {
+            commandline_parse();
+            switch (commandline_type()) {
                 case COMMAND_QUIT:
                     state_set_quit(state, true);
                     break;
                 case COMMAND_WRITE:
-                    action_write(state, command_data(c));
+                    action_write(state, commandline_data());
                     break;
                 case COMMAND_EDIT:
-                    action_edit(state, command_data(c));
+                    action_edit(state, commandline_data());
                 default:
                     break;
             }
 
-            commandline_reset(commandline);
+            commandline_reset();
             state_pop_mode(state);
-            command_destroy(c);
             return;
 
         case KEY_BACKSPACE:
         case '\b':
         case 127:
-            if (commandline_len(commandline) <= 0) {
-                commandline_reset(commandline);
+            if (commandline_len() <= 0) {
+                commandline_reset();
                 state_pop_mode(state);
             }
 
-            commandline_popch(commandline);
+            commandline_popch();
             return;
 
         default:
-            commandline_putch(commandline, state_currkey(state));
+            commandline_putch(state_currkey(state));
             break;
     }
 }

--- a/src/draw.c
+++ b/src/draw.c
@@ -376,7 +376,7 @@ void wdraw_statusline(WINDOW *win, struct State *s)
         case MODE_COMMAND:
             addch(' ');
             addch(':');
-            addstr(commandline_str(state_commandline(s)));
+            addstr(commandline_str());
             break;
         case MODE_TERRAIN:
         case MODE_AWAIT_TERRAIN:

--- a/src/include/commandline.h
+++ b/src/include/commandline.h
@@ -3,20 +3,15 @@
 
 #include "enum.h"
 
-struct Command;
-struct Commandline;
+void commandline_reset(void);
 
-enum COMMAND command_type(const struct Command *c);
-char *command_data(const struct Command *c);
-void command_destroy(struct Command *c);
+size_t commandline_len(void);
+enum COMMAND commandline_type(void);
+const char *commandline_str(void);
+const char *commandline_data(void);
 
-void commandline_reset(struct Commandline *c);
-struct Commandline *commandline_create(void);
-void commandline_destroy(struct Commandline *c);
-size_t commandline_len(struct Commandline *c);
-const char *commandline_str(struct Commandline *c);
-void commandline_putch(struct Commandline *c, char ch);
-char commandline_popch(struct Commandline *c);
-struct Command *commandline_parse(struct Commandline *c);
+void commandline_putch(char ch);
+char commandline_popch(void);
+void commandline_parse(void);
 
 #endif

--- a/src/state.c
+++ b/src/state.c
@@ -6,7 +6,6 @@
 
 #include "include/action.h"
 #include "include/atlas.h"
-#include "include/commandline.h"
 #include "include/enum.h"
 #include "include/geometry.h"
 #include "include/interface.h"
@@ -43,7 +42,6 @@ struct State *state_create(void)
     state->win = NULL;
 
     state->atlas = atlas_create();
-    state->cmd = commandline_create();
     state->geometry = geometry_create();
     state->ui = ui_create();
 
@@ -115,7 +113,6 @@ void state_update(struct State *state)
 void state_destroy(struct State *state)
 {
     atlas_destroy(state->atlas);
-    commandline_destroy(state->cmd);
     geometry_destroy(state->geometry);
     ui_destroy(state->ui);
 
@@ -154,11 +151,6 @@ void state_clear_atlas(struct State *state)
 struct UserInterface *state_ui(const struct State *state)
 {
     return state->ui;
-}
-
-struct Commandline *state_commandline(const struct State *state)
-{
-    return state->cmd;
 }
 
 enum MODE state_mode(const struct State *state)


### PR DESCRIPTION
Using structs and generic infrastructure was over-complicating a structure that only needs one instance. Commandline data now managed at file scope.